### PR TITLE
Corrected IT technician account example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ dock = Dock()
 dock.items['persistent-apps'] = []
 for item in tech_dock:
     if os.path.exists(item):
-        item = dock.makeDockAppEntry(entry)
+        item = dock.makeDockAppEntry(item)
         dock.items['persistent-apps'].append(item)
 dock.save()
 ```


### PR DESCRIPTION
`item = dock.makeDockAppEntry(entry)` should be `item = dock.makeDockAppEntry(item)`