### PR TITLE
Added additional keys to Mutable keys

### DIFF
--- a/payload/Library/Python/2.7/site-packages/docklib.py
+++ b/payload/Library/Python/2.7/site-packages/docklib.py
@@ -42,7 +42,8 @@ class Dock:
         "magnification",
         "magnification-immutable",
         "magsize-immutable",
-        "show-progress-indicators" "contents-immutable",
+        "show-progress-indicators",
+        "contents-immutable",
         "size-immutable",
         "mineffect",
         "mineffect-immutable",
@@ -60,6 +61,11 @@ class Dock:
     if LooseVersion(mac_ver()[0]) >= LooseVersion("10.14"):
         _MUTABLE_KEYS.append("show-recents")
         _IMMUTABLE_KEYS.append("recent-apps")
+    if LooseVersion(mac_ver()[0]) >= LooseVersion("10.15"):
+        _MUTABLE_KEYS.append(
+            "dblclickbehavior", "show-recents-immutable", "windowtabbing"
+        )
+
     items = {}
 
     def __init__(self):

--- a/payload/Library/Python/2.7/site-packages/docklib.py
+++ b/payload/Library/Python/2.7/site-packages/docklib.py
@@ -31,8 +31,32 @@ class Dock:
     _DOCK_LAUNCHAGENT_ID = "com.apple.Dock.agent"
     _DOCK_LAUNCHAGENT_FILE = "/System/Library/LaunchAgents/com.apple.Dock.plist"
     _SECTIONS = ["persistent-apps", "persistent-others"]
-    _MUTABLE_KEYS = ["autohide", "orientation", "tilesize"]
+    _MUTABLE_KEYS = [
+        "autohide",
+        "orientation",
+        "tilesize",
+        "largesize",
+        "orientation-immutable",
+        "position-immutable",
+        "autohide-immutable",
+        "magnification",
+        "magnification-immutable",
+        "magsize-immutable",
+        "show-progress-indicators" "contents-immutable",
+        "size-immutable",
+        "mineffect",
+        "mineffect-immutable",
+        "size-immutable",
+        "minimize-to-application",
+        "minimize-to-application-immutable",
+        "show-process-indicators",
+        "launchanim",
+        "launchanim-immutable",
+    ]
+
     _IMMUTABLE_KEYS = ["mod-count", "trash-full"]
+    if LooseVersion(mac_ver()[0]) >= LooseVersion("10.12"):
+        _MUTABLE_KEYS.append("AllowDockFixupOverride")
     if LooseVersion(mac_ver()[0]) >= LooseVersion("10.14"):
         _MUTABLE_KEYS.append("show-recents")
         _IMMUTABLE_KEYS.append("recent-apps")


### PR DESCRIPTION
Don't merge yet. Working on getting some of these to have restricted values.
        "largesize",
        "orientation-immutable",
        "position-immutable",
        "autohide-immutable",
        "magnification",
        "magnification-immutable",
        "magsize-immutable",
        "show-progress-indicators" "contents-immutable",
        "size-immutable",
        "mineffect",
        "mineffect-immutable",
        "size-immutable",
        "minimize-to-application",
        "minimize-to-application-immutable",
        "show-process-indicators",
        "launchanim",
        "launchanim-immutable"

Added check for AllowDockFixupOverride for 10.12+