### PR TITLE
Fixed append to extend for py2+py3 compatibility

### DIFF
--- a/payload/Library/Python/2.7/site-packages/docklib.py
+++ b/payload/Library/Python/2.7/site-packages/docklib.py
@@ -64,8 +64,8 @@ class Dock:
         _MUTABLE_KEYS.append("show-recents")
         _IMMUTABLE_KEYS.append("recent-apps")
     if LooseVersion(mac_ver()[0]) >= LooseVersion("10.15"):
-        _MUTABLE_KEYS.append(
-            "dblclickbehavior", "show-recents-immutable", "windowtabbing"
+        _MUTABLE_KEYS.extend(
+            ["dblclickbehavior", "show-recents-immutable", "windowtabbing"]
         )
 
     items = {}


### PR DESCRIPTION
Fixes #20 but also begs the question...should we set this up for a pip install to allow pip2 or pip3 to install for the respective python versions OR update the path for the frameworks?